### PR TITLE
Enable WiFi Display

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -60,5 +60,19 @@
         <item>30</item>
         <item>15</item>
     </integer-array>
+    
+    <!-- Whether WiFi display is supported by this device.
+         There are many prerequisites for this feature to work correctly.
+         Here are a few of them:
+         * The WiFi radio must support WiFi P2P.
+         * The WiFi radio must support concurrent connections to the WiFi display and
+           to an access point.
+         * The Audio Flinger audio_policy.conf file must specify a rule for the "r_submix"
+           remote submix module.  This module is used to record and stream system
+           audio output to the WiFi display encoder in the media server.
+         * The remote submix module "audio.r_submix.default" must be installed on the device.
+         * The device must be provisioned with HDCP keys (for protected content).
+    -->
+    <bool name="config_enableWifiDisplay">true</bool>
 
 </resources>


### PR DESCRIPTION
This enables Wifi Display, also known as Miracast. Miracast is enabled and working by default on the stock ROM.
The requirements for working WiFi Display connections are available as a comment.

Just found this addition for my old phone (i9300):
https://github.com/SlimRoms/device_samsung_i9300/commit/e4a29e1837166daa0203728f35a2b9f98eac21de
