### PR TITLE
Support for lux_uds device in the board config

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -20,7 +20,7 @@ include device/motorola/msm8916-common/BoardConfigCommon.mk
 DEVICE_PATH := device/motorola/lux
 
 # Asserts
-TARGET_OTA_ASSERT_DEVICE := lux,xt1562,xt1563
+TARGET_OTA_ASSERT_DEVICE := lux,lux_uds,xt1562,xt1563
 
 # Init
 TARGET_INIT_VENDOR_LIB := libinit_lux


### PR DESCRIPTION
My device is appearing as lux_uds in the bootloader. It is a XT1562.
With this patch, I can flash and cyanogenmod works without issue.
